### PR TITLE
Add Portuguese translation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This web application demonstrates a simple chat box that translates any text you
 
 Open `index.html` in your browser. All pages initialize the `skapi-js` library and handle login state. Use the sign up form to create an account, then log in to access the chat page.
 
-Select a target language from the drop-down menu above the input box, type your text, and the app will display the translation. Messages are forwarded to OpenAI's API using Skapi's `clientSecretRequest` with the client secret name `gpt`.
+Select a target language (Spanish, French, German, Japanese, Chinese, Korean or Portuguese) from the drop-down menu above the input box, type your text, and the app will display the translation. Messages are forwarded to OpenAI's API using Skapi's `clientSecretRequest` with the client secret name `gpt`.

--- a/chat.html
+++ b/chat.html
@@ -85,6 +85,7 @@ window.addEventListener('DOMContentLoaded', () => {
     <option>Japanese</option>
     <option>Chinese</option>
     <option>Korean</option>
+    <option>Portuguese</option>
   </select>
   <textarea id="input" placeholder="Enter text to translate..." required style="height:80px;"></textarea>
   <input type="submit" value="Send">


### PR DESCRIPTION
## Summary
- enable Portuguese in the chat's language selector
- document Portuguese support in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685df31c62ac832697bf2605f7449850